### PR TITLE
Fix: Update validation command

### DIFF
--- a/src/commands/check-terraform-validate.yml
+++ b/src/commands/check-terraform-validate.yml
@@ -9,5 +9,5 @@ steps:
       name: Check Terraform syntax
       command: |
         find . -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m;
-        do (terraform init -input=false -backend=false "$m"; terraform validate "$m" && echo "√ $m") ||
+        do (terraform -chdir="$m" init -input=false -backend=false; terraform -chdir="$m" validate && echo "√ $m") ||
         exit 1 ; done


### PR DESCRIPTION
# Description

Update validation command to avoid the following error in 0.15:

```
The trailing [DIR] argument to specify the working directory for various commands is no longer supported. Use the global -chdir option instead. (#27664)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
