### PR TITLE
feat: allow speculative plans

### DIFF
--- a/src/commands/create-config-version.yml
+++ b/src/commands/create-config-version.yml
@@ -7,10 +7,15 @@ parameters:
     type: string
     description: Path to the Terraform files
     default: .
+  plan-only:
+    type: boolean
+    description: If the run should be speculative
+    default: false
 
 steps:
   - run:
       environment:
         TF_CONTENT_DIRECTORY: << parameters.path >>
+        PLAN_ONLY: << parameters.plan-only >>
       name: Create and upload a new configuration version
       command: <<include(scripts/create-configuration-version.sh)>>

--- a/src/jobs/tfc-run.yml
+++ b/src/jobs/tfc-run.yml
@@ -14,6 +14,10 @@ parameters:
     type: string
     description: Path to the Terraform configuration files
     default: .
+  plan-only:
+    type: boolean
+    description: If the run should be speculative
+    default: false
 
 steps:
   - checkout
@@ -22,6 +26,7 @@ steps:
       workspace: << parameters.workspace >>
   - create-config-version:
       path: << parameters.path >>
+      plan-only: << parameters.plan-only >>
   - trigger-run:
       organization: << parameters.organization >>
       workspace: << parameters.workspace >>

--- a/src/scripts/create-configuration-version.sh
+++ b/src/scripts/create-configuration-version.sh
@@ -18,14 +18,19 @@ echo "$UPLOAD_FILE_NAME created successfully!"
 
 echo "Creating new configuration version..."
 
-echo '{
+REQUEST_JSON_STRING=$( jq -n \
+--arg plan "$PLAN_ONLY" \
+'{
   "data": {
     "type": "configuration-versions",
     "attributes": {
-      "auto-queue-runs": false
+      "auto-queue-runs": false,
+      "speculative" : $plan
     } 
   }  
-}' > ./create_config_version.json
+}')
+
+echo "$REQUEST_JSON_STRING" > ./create_config_version.json
 
 RESPONSE_CONFIG=$(curl -s \
   --header "Authorization: Bearer $TERRAFORM_TOKEN" \


### PR DESCRIPTION
# Description

Allow plans triggered on TFC to be plan-only (speculative).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
