### PR TITLE
fix: trigger run only

### DIFF
--- a/src/commands/create-config-version.yml
+++ b/src/commands/create-config-version.yml
@@ -19,3 +19,7 @@ steps:
         PLAN_ONLY: << parameters.plan-only >>
       name: Create and upload a new configuration version
       command: <<include(scripts/create-configuration-version.sh)>>
+  - run:
+      name: Verify configuration version is ready
+      command: <<include(scripts/config-ready.sh)>>
+      

--- a/src/commands/create-config-version.yml
+++ b/src/commands/create-config-version.yml
@@ -22,4 +22,3 @@ steps:
   - run:
       name: Verify configuration version is ready
       command: <<include(scripts/config-ready.sh)>>
-      

--- a/src/commands/trigger-run.yml
+++ b/src/commands/trigger-run.yml
@@ -1,5 +1,5 @@
 description: >
-  Triggers a run on Terraform Cloud. Expects TF_CONFIG_VERSION_ID to be present in BASH_EVN
+  Triggers a run on Terraform Cloud. Expects TF_CONFIG_VERSION_ID to be present in BASH_EVN, otherwise the latest version will be used
 
 parameters:
   organization:
@@ -10,9 +10,6 @@ parameters:
     description: Name of the workspace
 
 steps:
-  - run:
-      name: Verify configuration version is ready
-      command: <<include(scripts/config-ready.sh)>>
   - run:
       environment:
         TF_ORG_NAME: << parameters.organization >>

--- a/src/jobs/tfc-create-config-run.yml
+++ b/src/jobs/tfc-create-config-run.yml
@@ -1,4 +1,4 @@
-description: Triggers a run on Terraform Cloud
+description: Creates and uploads a new configuration version, and triggers a run on Terraform Cloud
 
 docker:
   - image: cimg/base:2021.05
@@ -10,12 +10,22 @@ parameters:
   workspace:
     type: string
     description: Terraform Cloud workspace name
+  path:
+    type: string
+    description: Path to the Terraform configuration files
+    default: .
+  plan-only:
+    type: boolean
+    description: If the configuration should be speculative
+    default: false
 
 steps:
   - checkout
   - lookup-workspace:
       organization: << parameters.organization >>
       workspace: << parameters.workspace >>
+  - create-config-version:
+      path: << parameters.path >>
   - trigger-run:
       organization: << parameters.organization >>
       workspace: << parameters.workspace >>


### PR DESCRIPTION
# Description

This adds the ability to only trigger a run, skipping the creation/upload of a configuration version.

Tested on this branch: https://github.com/HomeXLabs/hx-infrastructure/tree/nk-deadman-container
Test job: https://app.circleci.com/pipelines/github/HomeXLabs/hx-infrastructure/9007/workflows/4bfc9ab6-ab61-44f7-bf35-e03b38329031/jobs/2268

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
