### PR TITLE
feat: clear previous runs from tfc workspace

### DIFF
--- a/src/commands/clear-previous-runs.yml
+++ b/src/commands/clear-previous-runs.yml
@@ -1,5 +1,5 @@
 description: >
-  Clears all pending, planning, and queued runs for a workspace. Expects TF_WORKSPACE_ID to be present in BASH_ENV
+  Clears all pending, planning, and queued runs for a workspace. Expects TF_WORKSPACE_ID to be present in BASH_ENV (from `lookup-workspace` step)
 
 parameters:
   organization:

--- a/src/commands/clear-previous-runs.yml
+++ b/src/commands/clear-previous-runs.yml
@@ -1,0 +1,18 @@
+description: >
+  Clears all pending, planning, and queued runs for a workspace. Expects TF_WORKSPACE_ID to be present in BASH_ENV
+
+parameters:
+  organization:
+    type: string
+    description: Organization name
+  workspace:
+    type: string
+    description: Name of the workspace
+
+steps:
+  - run:
+      environment:
+        TF_ORG_NAME: << parameters.organization >>
+        TF_WORKSPACE_NAME: << parameters.workspace >>
+      name: Clear previous runs from Terraform cloud
+      command: <<include(scripts/cancel-or-discard.sh)>>

--- a/src/jobs/tfc-run.yml
+++ b/src/jobs/tfc-run.yml
@@ -10,12 +10,22 @@ parameters:
   workspace:
     type: string
     description: Terraform Cloud workspace name
+  clear-previous:
+    type: boolean
+    default: true
+    description: Whether to discard/cancel previous runs triggered by CCI
 
 steps:
   - checkout
   - lookup-workspace:
       organization: << parameters.organization >>
       workspace: << parameters.workspace >>
+  - when:
+      condition: << parameters.clear-previous >>
+      steps:
+        - clear-previous-runs:
+            organization: << parameters.organization >>
+            workspace: << parameters.workspace >>
   - trigger-run:
       organization: << parameters.organization >>
       workspace: << parameters.workspace >>

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-source $BASH_ENV;
+#source $BASH_ENV;
+
+TERRAFORM_TOKEN="ijwdjX8JPdv90g.atlasv1.kI58hshfsG6bG3LR3ug0jfPp2wFKCv9eyvm1797mzYM3KgRFpjPbLMgsK4L7ka7ttdY"
+TF_WORKSPACE_ID="ws-6VSrguRA56vWDJUN"
 
 echo "Checking for previous runs to clear for $TF_ORG_NAME/$TF_WORKSPACE_NAME..."
 
@@ -11,29 +14,33 @@ RESPONSE_RUNS=$(curl -s \
   https://app.terraform.io/api/v2/workspaces/$TF_WORKSPACE_ID/runs?page%5Bsize%5D=50)
 
 # Filter the response to run IDs triggered by CCI that would be holding back future runs
-declare -a runs=$(
-  jq -r '.data[] 
+runs=$(
+  jq -rc '.data[] 
   | select (.attributes.message | startswith("CCI-")) 
   | select(.attributes.status as $status 
   | ["pending","plan_queued","planning","planned","cost_estimating","cost_estimated","policy_checking","policy_override","policy_checked"] 
   | index($status)) 
-  | .id' <<< "$RESPONSE_RUNS")
+  | .id' <<< "$RESPONSE_RUNS" | tr '\n' ' ')
 
-echo "Runs IDs to discard/cancel: $runs"
+runs_arr=($runs)
+
+echo "Runs IDs to discard/cancel: $runs_arr"
 
 # Attempt to discard first - works for pending/queued runs, if fails attempt to cancel, works for runs currently being planned
-for run in "${runs[@]}"
+for run in "${runs_arr[@]}"
 do 
   if [[ ! -z $run ]]; then
     echo "Attempting to discard run with id: $run"
     DISCARD_RESPONSE=$(curl -s \
     --header "Authorization: Bearer $TERRAFORM_TOKEN" \
+    --header "Content-Type: application/vnd.api+json" \
     --request POST \
     https://app.terraform.io/api/v2/runs/$run/actions/discard)
     if [[ $DISCARD_RESPONSE != null ]]; then
       echo "Unable to discard, attempting to cancel run with id: $run"
       CANCEL_RESPONSE=$(curl -s \
       --header "Authorization: Bearer $TERRAFORM_TOKEN" \
+      --header "Content-Type: application/vnd.api+json" \
       --request POST \
       https://app.terraform.io/api/v2/runs/$run/actions/cancel)
       if [[ $CANCEL_RESPONSE != null ]]; then

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -31,7 +31,7 @@ do
     --request POST \
     https://app.terraform.io/api/v2/runs/$run/actions/discard)
     if [[ $DISCARD_RESPONSE != null ]]; then
-      echo "Unable to disacrd, attempting to cancel run with id: $run"
+      echo "Unable to discard, attempting to cancel run with id: $run"
       CANCEL_RESPONSE=$(curl -s \
       --header "Authorization: Bearer $TERRAFORM_TOKEN" \
       --request POST \

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -22,7 +22,7 @@ declare -a runs=$(
 echo "Runs IDs to discard/cancel: $runs"
 
 # Attempt to discard first - works for pending/queued runs, if fails attempt to cancel, works for runs currently being planned
-for run in "${runs[@]}"
+for run in `${runs[@]}`
 do 
   if [ ! -z $run ]; then
     DISCARD_RESPONSE=$(curl -s \

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -13,7 +13,7 @@ RESPONSE_RUNS=$(curl -s \
 # Filter the response to run IDs triggered by CCI that would be holding back future runs
 declare -a runs=$(
   jq -r '.data[] 
-  | select (.attributes.message | startswith("CCI-")) 
+  | select (.attributes.message | startswith("")) 
   | select(.attributes.status as $status 
   | ["pending","plan_queued","planning","planned","cost_estimating","cost_estimated","policy_checking","policy_override","policy_checked"] 
   | index($status)) 
@@ -22,9 +22,9 @@ declare -a runs=$(
 echo "Runs IDs to discard/cancel: $runs"
 
 # Attempt to discard first - works for pending/queued runs, if fails attempt to cancel, works for runs currently being planned
-for run in `${runs[@]}`
+for run in "${runs[@]}"
 do 
-  if [ ! -z $run ]; then
+  if [[ ! -z $run ]]; then
     DISCARD_RESPONSE=$(curl -s \
     --header "Authorization: Bearer $TERRAFORM_TOKEN" \
     --header "Content-Type: application/vnd.api+json" \

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+source $BASH_ENV;
+
+echo "Checking for previous runs to clear for $TF_ORG_NAME/$TF_WORKSPACE_NAME..."
+
+# Get 50 most recent runs to check through
+RESPONSE_RUNS=$(curl -s \
+  --header "Authorization: Bearer $TERRAFORM_TOKEN" \
+  --header "Content-Type: application/vnd.api+json" \
+  https://app.terraform.io/api/v2/workspaces/$TF_WORKSPACE_ID/runs?page%5Bsize%5D=50)
+
+#echo $RESPONSE_RUNS | jq 'select(.data[].attributes.status | IN(["pending","plan_queued","planning","planned","cost_estimating","cost_estimated","policy_checking","policy_checked"])) | .data[].id'
+
+# Filter the response to run IDs triggered by CCI that would be holding back future runs
+declare -a runs=$(
+  jq -r '.data[] 
+  | select (.attributes.message | startswith("CCI-")) 
+  | select(.attributes.status as $status 
+  | ["pending","plan_queued","planning","planned","cost_estimating","cost_estimated","policy_checking","policy_checked"] 
+  | index($status)) 
+  | .id' <<< "$RESPONSE_RUNS")
+
+echo "Runs IDs to discard/cancel: $runs"
+
+# Attempt to discard first - works for pending/queued runs, if fails attempt to cancel, works for runs currently being planned
+for run in "${runs[@]}"
+do 
+  if [ ! -z $run ]; then
+    DISCARD_RESPONSE=$(curl -s \
+    --header "Authorization: Bearer $TERRAFORM_TOKEN" \
+    --header "Content-Type: application/vnd.api+json" \
+    --request POST \
+    https://app.terraform.io/api/v2/runs/$run/actions/discard)
+    if [[ $DISCARD_RESPONSE != null ]]; then
+      CANCEL_RESPONSE=$(curl -s \
+      --header "Authorization: Bearer $TERRAFORM_TOKEN" \
+      --header "Content-Type: application/vnd.api+json" \
+      --request POST \
+      https://app.terraform.io/api/v2/runs/$run/actions/cancel)
+      if [[ $CANCEL_RESPONSE != null ]]; then
+        echo "Failed to discard/cancel https://app.terraform.io/app/$TF_ORG_NAME/$TF_WORKSPACE_NAME/runs/$run"
+        exit 1
+      else
+        echo "Cancelled https://app.terraform.io/app/$TF_ORG_NAME/$TF_WORKSPACE_NAME/runs/$run"
+      fi
+    else
+      echo "Discarded https://app.terraform.io/app/$TF_ORG_NAME/$TF_WORKSPACE_NAME/runs/$run"
+    fi
+  fi
+done
+
+echo "All previous runs have been cleared"

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -31,6 +31,7 @@ do
     --request POST \
     https://app.terraform.io/api/v2/runs/$run/actions/discard)
     if [[ $DISCARD_RESPONSE != null ]]; then
+      echo "Unable to disacrd, attempting to cancel run with id: $run"
       CANCEL_RESPONSE=$(curl -s \
       --header "Authorization: Bearer $TERRAFORM_TOKEN" \
       --request POST \

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -13,7 +13,7 @@ RESPONSE_RUNS=$(curl -s \
 # Filter the response to run IDs triggered by CCI that would be holding back future runs
 declare -a runs=$(
   jq -r '.data[] 
-  | select (.attributes.message | startswith("")) 
+  | select (.attributes.message | startswith("CCI-")) 
   | select(.attributes.status as $status 
   | ["pending","plan_queued","planning","planned","cost_estimating","cost_estimated","policy_checking","policy_override","policy_checked"] 
   | index($status)) 
@@ -25,15 +25,14 @@ echo "Runs IDs to discard/cancel: $runs"
 for run in "${runs[@]}"
 do 
   if [[ ! -z $run ]]; then
+    echo "Attempting to discard run with id: $run"
     DISCARD_RESPONSE=$(curl -s \
     --header "Authorization: Bearer $TERRAFORM_TOKEN" \
-    --header "Content-Type: application/vnd.api+json" \
     --request POST \
     https://app.terraform.io/api/v2/runs/$run/actions/discard)
     if [[ $DISCARD_RESPONSE != null ]]; then
       CANCEL_RESPONSE=$(curl -s \
       --header "Authorization: Bearer $TERRAFORM_TOKEN" \
-      --header "Content-Type: application/vnd.api+json" \
       --request POST \
       https://app.terraform.io/api/v2/runs/$run/actions/cancel)
       if [[ $CANCEL_RESPONSE != null ]]; then

--- a/src/scripts/cancel-or-discard.sh
+++ b/src/scripts/cancel-or-discard.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-#source $BASH_ENV;
-
-TERRAFORM_TOKEN="ijwdjX8JPdv90g.atlasv1.kI58hshfsG6bG3LR3ug0jfPp2wFKCv9eyvm1797mzYM3KgRFpjPbLMgsK4L7ka7ttdY"
-TF_WORKSPACE_ID="ws-6VSrguRA56vWDJUN"
+source $BASH_ENV;
 
 echo "Checking for previous runs to clear for $TF_ORG_NAME/$TF_WORKSPACE_NAME..."
 

--- a/src/scripts/trigger-run.sh
+++ b/src/scripts/trigger-run.sh
@@ -59,7 +59,7 @@ else
   }')
 fi
 
-echo $"REQUEST:\n$RUN_JSON_STRING"
+echo $"REQUEST: $RUN_JSON_STRING"
 
 echo "$RUN_JSON_STRING" > ./create_run.json
 


### PR DESCRIPTION
# Description

This command will discard/cancel currently queued/pending/planning runs triggered by CCI. This will be useful for sandbox deployments where many commits may be triggering lots of runs on a branch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
