### PR TITLE
chore: remove slack bot config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: Create release
           command: |
             export SEMANTIC_RELEASE_PACKAGE=${CIRCLE_PROJECT_REPONAME}
-            npx -p semantic-release -p semantic-release/git -p semantic-release/changelog -p semantic-release-slack-bot semantic-release
+            npx -p semantic-release -p semantic-release/git -p semantic-release/changelog semantic-release
       - slack/status:
           fail_only: true
           failure_message: ":rotating_light: Circle Vault Orb release has failed! $FAILURE_MESSAGE"

--- a/.releaserc
+++ b/.releaserc
@@ -8,10 +8,6 @@
     ["@semantic-release/git", {
       "assets": ["docs/CHANGELOG.md"],
     }],
-    "@semantic-release/github",
-    ["semantic-release-slack-bot", {
-      "notifyOnSuccess": true,
-      "notifyOnFail": true
-    }]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
# Description

Removes the configuration for the slack bot from semantic release bot so it actually works

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
