### PR TITLE
fix: terraform init command no longer supports chdir arg

### DIFF
--- a/src/commands/check-terraform-validate.yml
+++ b/src/commands/check-terraform-validate.yml
@@ -9,5 +9,5 @@ steps:
       name: Check Terraform syntax
       command: |
         find . -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m;
-        do (terraform -chdir="$m" init -input=false -backend=false; terraform -chdir="$m" validate && echo "√ $m") ||
+        do (cd $m; terraform init -input=false -backend=false; terraform validate && echo "√ $m") ||
         exit 1 ; done


### PR DESCRIPTION
<!---
Please review the following Pull Request Checklist http://github.com/HomeXlabs/hx-infrastructure/docs/CHECKLIST_PR.md)
--->

# Description

Does a `cd` prior to running init instead of passing the now removed `chdir` argument.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
