### PR TITLE
fix: pin to pre go-1.18 version

### DIFF
--- a/src/commands/install-terraform.yml
+++ b/src/commands/install-terraform.yml
@@ -14,7 +14,7 @@ steps:
       name: Install Terraform
       command: |
         if [ "<<parameters.terraform-version >>" == "latest-required" ]; then
-          go get -d github.com/hashicorp/terraform-config-inspect@413b69327090029750844f6303b0767f10f6529d
+          go install github.com/hashicorp/terraform-config-inspect@413b69327090029750844f6303b0767f10f6529d
 
           echo "Finding terraform version from code"
           TERRAFORM_JSON=$(/go/bin/terraform-config-inspect ./ --json || true)

--- a/src/commands/install-terraform.yml
+++ b/src/commands/install-terraform.yml
@@ -14,7 +14,7 @@ steps:
       name: Install Terraform
       command: |
         if [ "<<parameters.terraform-version >>" == "latest-required" ]; then
-          go get github.com/hashicorp/terraform-config-inspect
+          go get -d github.com/hashicorp/terraform-config-inspect@413b69327090029750844f6303b0767f10f6529d
 
           echo "Finding terraform version from code"
           TERRAFORM_JSON=$(/go/bin/terraform-config-inspect ./ --json || true)


### PR DESCRIPTION
# Description

Pins to the go package version of https://github.com/hashicorp/terraform-config-inspect version prior to go 1.18 updates due to compatibility issues.

Updates the deprecated `go get` command to `go install`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
